### PR TITLE
Fix image atom color

### DIFF
--- a/src/atoms/plugins/atom.js
+++ b/src/atoms/plugins/atom.js
@@ -167,14 +167,16 @@ export class AtomManager {
       for (let i = 0; i < imageAtomsList.getAtomsCount(); i++) {
         atomScales[i] = this.viewer.atomScales[this.viewer.imageAtomsList[i][0]];
       }
-      const atomColors = [];
-      imageAtomsList.symbols.forEach((symbol, globalIndex) => {
+      const atomColors = this.viewer.imageAtomsList.map(([atomIndex]) => {
+        const baseColor = this.viewer.atomColors?.[atomIndex];
+        if (baseColor) {
+          return typeof baseColor.clone === "function" ? baseColor.clone() : new THREE.Color(baseColor);
+        }
+        const symbol = this.viewer.atoms.symbols[atomIndex];
         if (!this.settings[symbol]) {
           this.settings[symbol] = this.getDefaultSetting(symbol, imageAtomsList.species[symbol]?.element || symbol);
         }
-        // if this.viewer.atoms has color attribute in the specie domain, use it
-        const color = new THREE.Color(this.settings[symbol].color);
-        atomColors.push(color);
+        return new THREE.Color(this.settings[symbol].color);
       });
       const imageAtomsMesh = drawAtoms({
         scene: this.scene,


### PR DESCRIPTION
Colors for boundary/bonded image atoms are now derived from the original atom’s computed colors.