### PR TITLE
Polymesh improvements

### DIFF
--- a/src/atoms/plugins/polyhedra.js
+++ b/src/atoms/plugins/polyhedra.js
@@ -210,8 +210,11 @@ export class PolyhedraManager {
   drawPolyhedraMesh(atoms, materialType = "standard", showEdges = true) {
     const material = materials[materialType].clone();
     material.transparent = true;
-    material.opacity = 0.8;
-    material.vertexColors = true; // Ensure vertex colors are applied
+    material.opacity = 0.50; // reduced opacity since DoubleSide is now used.
+    material.vertexColors = true;
+    material.depthWrite = false;     // prevents faces from blocking each other
+    material.side = THREE.DoubleSide;
+
     const geometry = new THREE.BufferGeometry();
     geometry.setAttribute("position", new THREE.Float32BufferAttribute(this.allVertices, 3));
     geometry.setAttribute("normal", new THREE.Float32BufferAttribute(this.allNormals, 3));

--- a/src/atoms/plugins/polyhedra.js
+++ b/src/atoms/plugins/polyhedra.js
@@ -210,7 +210,7 @@ export class PolyhedraManager {
   drawPolyhedraMesh(atoms, materialType = "standard", showEdges = true) {
     const material = materials[materialType].clone();
     material.transparent = true;
-    material.opacity = 0.50; // reduced opacity since DoubleSide is now used.
+    material.opacity = 0.60;
     material.vertexColors = true;
     material.depthWrite = false;     // prevents faces from blocking each other
     material.side = THREE.DoubleSide;
@@ -230,10 +230,10 @@ export class PolyhedraManager {
     // Generate edges from the same geometry
     const edgesGeometry = new THREE.EdgesGeometry(geometry, 1); // 1 = angle threshold
     const lineMaterial = new THREE.LineBasicMaterial({
-      color: 0x000,
+      color: 0xb4b4b4,
       linewidth: 1,
       transparent: true,
-      opacity: 0.25,
+      opacity: 0.50,
     });
     const edgesMesh = new THREE.LineSegments(edgesGeometry, lineMaterial);
 

--- a/src/atoms/plugins/polyhedra.js
+++ b/src/atoms/plugins/polyhedra.js
@@ -207,7 +207,7 @@ export class PolyhedraManager {
     this.vertexAtomMap = vertexAtomMap;
   }
 
-  drawPolyhedraMesh(atoms, materialType = "standard") {
+  drawPolyhedraMesh(atoms, materialType = "standard", showEdges = true) {
     const material = materials[materialType].clone();
     material.transparent = true;
     material.opacity = 0.8;
@@ -223,6 +223,23 @@ export class PolyhedraManager {
     mesh.userData.notSelectable = true;
     mesh.layers.set(1);
 
+     if (showEdges) {
+    // Generate edges from the same geometry
+    const edgesGeometry = new THREE.EdgesGeometry(geometry, 1); // 1 = angle threshold
+    const lineMaterial = new THREE.LineBasicMaterial({
+      color: 0x000,
+      linewidth: 1,
+      transparent: true,
+      opacity: 0.25,
+    });
+    const edgesMesh = new THREE.LineSegments(edgesGeometry, lineMaterial);
+
+    edgesMesh.renderOrder = 1001; // Render edges after the transparent mesh
+    edgesMesh.layers.set(1);
+
+    // Add edges as a child of the main mesh
+    mesh.add(edgesMesh);
+  }
     return mesh;
   }
 


### PR DESCRIPTION
Currently the polyhedral rendering has a  small issue where it does not to respect transparency and correct rendering is a function of camera position. 

Image 1: Transparency works as expected, behind polyhedra are rendering correctly
<img width="1156" height="861" alt="image" src="https://github.com/user-attachments/assets/cff4f5e2-9a94-4cad-b628-c00bc14fdea2" />

Rotation by 180 around b:
Image 2: Transparency does not work as expect
<img width="1229" height="873" alt="image" src="https://github.com/user-attachments/assets/ac36d692-1bdb-4bb2-a1ef-5b3d77659f1d" />

Instead, ive switched the mesh rendering side to be Three.DoubleSide, this allows rendering out the box,
Additionaly, i've added edge drawing to these polyhedra, this probably comes with a small performance hit (but im fairly sure its minimal at best.) showEdges=true

<img width="1118" height="866" alt="image" src="https://github.com/user-attachments/assets/36273ea1-071c-4755-b1d6-4ed312932c97" />

The showEdges flag could be exposed to the controller api, both color, transparency and on/off so that these can be toggled in the controls panel., but this is not currently done.
